### PR TITLE
Make CI script more concise

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       remote: ${{ steps.latest_remote_tag.outputs.ver }}
       local: ${{ steps.latest_local_release.outputs.ver }}
@@ -30,7 +30,7 @@ jobs:
           )
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [check-version]
     if: |
       (needs.check-version.outputs.remote != needs.check-version.outputs.local) &&
@@ -38,25 +38,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install libfuse-dev -y
-      - name: Modify build file
-        run: |
-          REM_VER=${{ needs.check-version.outputs.remote }}
-
-          echo Updating version string
-          sed -i "s/VERSION\=.*/VERSION\='$REM_VER'/im" ./build
-          echo Removing checksum validation
-          sed -i '/${B2SUM}/d' ./build
-          echo Converting potential Windows styles
-          sed -i -e 's/\r$//' ./build
-      - name: Make executable
-        run: |
-          echo Loading FUSE library
-          modprobe fuse
-          echo Making script executable
-          chmod +x ./build
+        run: sudo apt-get install -y fuse
       - name: Build
-        run: ./build
+        run: ./build '${{ needs.check-version.outputs.remote }}'
       - name: Publish new release
         id: new_release
         uses: actions/create-release@v1

--- a/build
+++ b/build
@@ -1,10 +1,37 @@
 #!/bin/bash
 set -euo pipefail; IFS=$'\n\t'
 
+help () {
+  cat <<-'EOF'
+build
+Scripts which packages AWS CLI v2 into an AppImage binary.
 
+Usage:
+  ./build <version>
+  ./build [-h|--help]
 
-VERSION='2.1.14'
-B2SUM='fe01a5c205047b4e0d359ea851854b5e1d5ab1f23a044218f6924c67f2dd1810160d70d66ec07283ba5d68cf541a3c4ac4cf6d2f319df3d5fa188abeab93229d'
+  <version>     Version of AWS CLI
+  -h, --help    Display this message
+
+Example:
+  ./build 2.0.0
+  ./build 2.1.14
+  ./build -h
+  ./build --help
+EOF
+}
+
+if (( $# != 1 )); then
+  help
+  exit 1
+fi
+
+if [[ "${1}" == '-h' || "${1}" == '--help' ]]; then
+  help
+  exit
+fi
+
+VERSION="${1}"
 
 
 
@@ -22,7 +49,6 @@ chmod +x appimagetool aws.AppDir/AppRun
 
 # Download and extract AWSCliv2
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${VERSION}.zip" -o aws.zip
-b2sum -c <<< "${B2SUM} ./aws.zip"
 unzip -q aws.zip 'aws/dist/*'
 mv aws/dist aws.AppDir/usr/bin
 


### PR DESCRIPTION
1.  Made 'build' script accept ARGV[1] as a version of AWSCLIv2
2.  Install just 'fuse' instead of 'libfuse-dev'
3.  'fuse' package already calls `modprobe fuse` as a postinstall    script, skipping it
4.  Removed checksum validation since it is impossible to automate
5.  Don't care about CRLF since build script doesn't have it
6.  Change and fix the version of GitHub Actions runner as Ubuntu 20.04    (it was 18.04)
7.  Skip `apt-get update`